### PR TITLE
Adding new route into api which, giving the exact name of a scenario, return the description of scenario

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,8 @@ Make your change. Add tests for your change. Make the tests pass:
 ./gradlew test
 ```
 
+
+
 Push to your fork and [submit a pull request][pr].
 
 Some things that will increase the chance that your pull request is accepted:

--- a/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/scenario/dao/ScenarioQueryImpl.java
+++ b/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/scenario/dao/ScenarioQueryImpl.java
@@ -38,6 +38,12 @@ class ScenarioQueryImpl extends BaseMorphiaQuery<Scenario> implements ScenarioQu
     }
 
     @Override
+    public ScenarioQuery withName(String name) {
+        configureQuery(q -> q.field("info.name").equal(name));
+        return this;
+    }
+
+    @Override
     public ScenarioQuery orderedByName() {
         configureQuery(q -> q.order("info.name"));
         return this;

--- a/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/scenario/domain/ScenarioQuery.java
+++ b/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/scenario/domain/ScenarioQuery.java
@@ -12,6 +12,8 @@ public interface ScenarioQuery {
 
     ScenarioQuery withSearch(String search);
 
+    ScenarioQuery withName(String name);
+
     ScenarioQuery orderedByName();
 
     ScenarioQuery withSelectedTags(TagSelection tagSelection);

--- a/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/scenario/rest/GetScenariiRequestParams.java
+++ b/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/scenario/rest/GetScenariiRequestParams.java
@@ -15,6 +15,9 @@ public class GetScenariiRequestParams {
     @QueryParam("search")
     private String search;
 
+    @QueryParam("name")
+    private String name;
+
     @QueryParam("tag")
     private Set<String> tags;
 
@@ -43,6 +46,14 @@ public class GetScenariiRequestParams {
 
     public void setSearch(String search) {
         this.search = search;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     public Set<String> getTags() {

--- a/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/scenario/rest/ScenarioResource.java
+++ b/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/scenario/rest/ScenarioResource.java
@@ -71,6 +71,13 @@ public class ScenarioResource {
     }
 
     @GET
+    @Path("exact")
+    public ScenarioHistoryItemView getLastScenariiTested(@BeanParam final GetScenariiRequestParams requestParams) {
+        final Consumer<ScenarioQuery> query = prepareQueryFromRequestParams(requestParams);
+        return scenarioViewAccess.getLastScenariiTested(query);
+    }
+
+    @GET
     @Path("tags")
     public List<ScenarioTagStats> getTagStats(@BeanParam final GetScenariiRequestParams requestParams) {
         if (!requestParams.getExcludedTags().isEmpty()) {
@@ -201,7 +208,9 @@ public class ScenarioResource {
             if (!Strings.isNullOrEmpty(requestParams.getSearch())) {
                 q.withSearch(requestParams.getSearch());
             }
-
+            if (!Strings.isNullOrEmpty(requestParams.getName())) {
+                q.withName(requestParams.getName());
+            }
             final TagSelection tagSelection = new TagSelection(requestParams.getTags(), requestParams.getExcludedTags());
             q.withSelectedTags(tagSelection);
         };

--- a/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/scenario/views/ScenarioViewAccess.java
+++ b/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/scenario/views/ScenarioViewAccess.java
@@ -129,6 +129,16 @@ public class ScenarioViewAccess {
             .collect(Collectors.toList());
     }
 
+    public ScenarioHistoryItemView getLastScenariiTested(final Consumer<ScenarioQuery> preparator) {
+        final Query<Scenario> query = scenarioDAO.prepareTypedQuery(preparator);
+        final Scenario scenario = MorphiaUtils.streamQuery(query).findFirst().orElse(null);
+        if(scenario == null) {
+            return new ScenarioHistoryItemView(); // empty object
+        }
+        List<ScenarioHistoryItemView> scenariosHistory = getScenarioHistory(scenario.getScenarioKey());
+        return scenariosHistory.get(0);
+    }
+
     public ScenarioStats getStats(final Consumer<ScenarioQuery> preparator) {
         final ScenarioStats stats = new ScenarioStats();
 

--- a/zucchini-ui-e2e-tests/cypress.json
+++ b/zucchini-ui-e2e-tests/cypress.json
@@ -1,3 +1,3 @@
 {
-  "baseUrl": "http://localhost:9000/"
+  "baseUrl": "http://localhost:8080/"
 }

--- a/zucchini-ui-e2e-tests/cypress.json
+++ b/zucchini-ui-e2e-tests/cypress.json
@@ -1,3 +1,3 @@
 {
-  "baseUrl": "http://localhost:8080/"
+  "baseUrl": "http://localhost:9000/"
 }


### PR DESCRIPTION
Adding new route into api which, giving the exact name of a scenario, return the description of scenario return the description of scenario (id, lastTestRunned, status, ..) + change the baseUrl for cypress from 9000 to 8080 because test fails otherwise, the URL should be the front url (9000) and not the back one (8080).

I'm not sure about the name of the route i.e /scenarii/exact?name=blabla. I don't really like the "exact" word but I didn't found anything better.