### PR TITLE
Allowing Zucchini to rebuild Cucumber Rerun logs

### DIFF
--- a/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/feature/domain/Feature.java
+++ b/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/feature/domain/Feature.java
@@ -1,7 +1,6 @@
 package io.zucchiniui.backend.feature.domain;
 
 import io.zucchiniui.backend.shared.domain.BasicInfo;
-import io.zucchiniui.backend.shared.domain.Location;
 import io.zucchiniui.backend.support.ddd.BaseEntity;
 import xyz.morphia.annotations.Entity;
 import xyz.morphia.annotations.Id;
@@ -48,11 +47,6 @@ public class Feature extends BaseEntity<String> {
     private Set<String> tags = new HashSet<>();
 
     /**
-     * Location.
-     */
-    private Location location;
-
-    /**
      * Description.
      */
     private String description;
@@ -95,9 +89,8 @@ public class Feature extends BaseEntity<String> {
      * @param featureKey Feature key
      * @param testRunId  Test run ID
      * @param info       Basic information
-     * @param location   Feature location
      */
-    public Feature(final String featureKey, final String testRunId, final BasicInfo info, final Location location, final String language) {
+    public Feature(final String featureKey, final String testRunId, final BasicInfo info, final String language) {
         id = UUID.randomUUID().toString();
         status = FeatureStatus.NOT_RUN;
 
@@ -108,7 +101,6 @@ public class Feature extends BaseEntity<String> {
         this.featureKey = featureKey;
         this.testRunId = testRunId;
         this.info = info;
-        this.location = location;
         this.language = language;
     }
 
@@ -127,9 +119,8 @@ public class Feature extends BaseEntity<String> {
 
         info = other.info;
         tags = new HashSet<>(other.tags);
-        location = other.location;
-        description = other.description;
 
+        description = other.description;
         if (other.group != null) {
             group = other.group;
         }
@@ -204,10 +195,6 @@ public class Feature extends BaseEntity<String> {
 
     public Set<String> getTags() {
         return Collections.unmodifiableSet(tags);
-    }
-
-    public Location getLocation() {
-        return location;
     }
 
     public String getDescription() {

--- a/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/reportconverter/converter/ReportConverter.java
+++ b/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/reportconverter/converter/ReportConverter.java
@@ -71,7 +71,8 @@ public class ReportConverter {
                 scenarioBuilders.add(scenarioBuilder);
 
             } else if (reportFeatureElement instanceof ReportBackground) {
-                backgroundBuilderConsumer = reportScenarioConverter.createBackgroundBuilderConsumer((ReportBackground) reportFeatureElement);
+                backgroundBuilderConsumer = reportScenarioConverter.createBackgroundBuilderConsumer(feature,
+                    (ReportBackground) reportFeatureElement);
             } else if (reportFeatureElement instanceof ReportScenarioOutline) {
                 LOGGER.debug("Ignoring scenario outline: {}", reportFeatureElement);
             } else {

--- a/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/reportconverter/converter/ReportFeatureConverter.java
+++ b/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/reportconverter/converter/ReportFeatureConverter.java
@@ -26,16 +26,15 @@ class ReportFeatureConverter {
 
         final BasicInfo info = new BasicInfo(
             ConversionUtils.trimString(reportFeature.getKeyword()),
-            ConversionUtils.trimString(reportFeature.getName())
-        );
-
-        final Location location = new Location(
-            ConversionUtils.trimString(reportFeature.getFilename()),
-            reportFeature.getLine()
+            ConversionUtils.trimString(reportFeature.getName()),
+            new Location(
+                ConversionUtils.trimString(reportFeature.getFilename()),
+                reportFeature.getLine()
+            )
         );
 
         final String language = getLanguage(reportFeature);
-        final Feature feature = new Feature(featureKey, testRunId, info, location, language);
+        final Feature feature = new Feature(featureKey, testRunId, info, language);
         feature.setDescription(reportFeature.getDescription());
         group.ifPresent(feature::setGroup);
 

--- a/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/reportconverter/converter/ReportScenarioConverter.java
+++ b/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/reportconverter/converter/ReportScenarioConverter.java
@@ -25,9 +25,12 @@ class ReportScenarioConverter {
 
     public ScenarioBuilder createScenarioBuilder(final Feature parentFeature, final ReportScenario reportScenario) {
 
+        final String fileName = parentFeature.getInfo().getLocation().getFilename();
+
         final BasicInfo scenarioInfo = new BasicInfo(
             ConversionUtils.trimString(reportScenario.getKeyword()),
-            ConversionUtils.trimString(reportScenario.getName())
+            ConversionUtils.trimString(reportScenario.getName()),
+            new Location(fileName, reportScenario.getLine())
         );
 
         final Set<String> scenarioTags = reportScenario.getTags().stream()
@@ -48,7 +51,7 @@ class ReportScenarioConverter {
             .withComment(comment);
 
         for (final ReportStep reportStep : reportScenario.getSteps()) {
-            scenarioBuilder.addStep(b -> buildStep(reportStep, b));
+            scenarioBuilder.addStep(b -> buildStep(fileName, reportStep, b));
         }
 
         for (final ReportAroundAction reportAroundAction : reportScenario.getBeforeActions()) {
@@ -62,23 +65,25 @@ class ReportScenarioConverter {
         return scenarioBuilder;
     }
 
-    public Consumer<BackgroundBuilder> createBackgroundBuilderConsumer(final ReportBackground reportBackground) {
+    public Consumer<BackgroundBuilder> createBackgroundBuilderConsumer(final Feature parentFeature, final ReportBackground reportBackground) {
         return backgroundBuilder -> {
 
+            final String fileName = parentFeature.getInfo().getLocation().getFilename();
             final BasicInfo backgroundInfo = new BasicInfo(
                 ConversionUtils.trimString(reportBackground.getKeyword()),
-                ConversionUtils.trimString(reportBackground.getName())
+                ConversionUtils.trimString(reportBackground.getName()),
+                new Location(fileName, reportBackground.getLine())
             );
 
             backgroundBuilder.withInfo(backgroundInfo);
 
             for (final ReportStep reportStep : reportBackground.getSteps()) {
-                backgroundBuilder.addStep(b -> buildStep(reportStep, b));
+                backgroundBuilder.addStep(b -> buildStep(fileName, reportStep, b));
             }
         };
     }
 
-    private static void buildStep(final ReportStep reportStep, final StepBuilder stepBuilder) {
+    private static void buildStep(String fileName, final ReportStep reportStep, final StepBuilder stepBuilder) {
 
         final List<Argument> arguments = reportStep.getMatch().getArguments().stream()
             .filter(a -> !Strings.isNullOrEmpty(a.getValue()))
@@ -88,6 +93,7 @@ class ReportScenarioConverter {
         final BasicInfo stepInfo = new BasicInfo(
             ConversionUtils.trimString(reportStep.getKeyword()),
             ConversionUtils.trimString(reportStep.getName()),
+            new Location(fileName, reportStep.getLine()),
             arguments
         );
 

--- a/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/shared/domain/BasicInfo.java
+++ b/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/shared/domain/BasicInfo.java
@@ -11,6 +11,8 @@ public final class BasicInfo {
 
     private String name;
 
+    private Location location;
+
     private List<Argument> arguments = new ArrayList<>();
 
     /**
@@ -19,13 +21,14 @@ public final class BasicInfo {
     private BasicInfo() {
     }
 
-    public BasicInfo(final String keyword, final String name) {
-        this(keyword, name, new ArrayList<>());
+    public BasicInfo(final String keyword, final String name, final Location location) {
+        this(keyword, name, location, new ArrayList<>());
     }
 
-    public BasicInfo(final String keyword, final String name, final List<Argument> arguments) {
+    public BasicInfo(final String keyword, final String name, final Location location, final List<Argument> arguments) {
         this.keyword = Objects.requireNonNull(keyword);
         this.name = Objects.requireNonNull(name);
+        this.location = Objects.requireNonNull(location);
         this.arguments = new ArrayList<>(arguments);
     }
 
@@ -35,6 +38,10 @@ public final class BasicInfo {
 
     public String getName() {
         return name;
+    }
+
+    public Location getLocation() {
+        return location;
     }
 
     public List<Argument> getArguments() {
@@ -54,18 +61,19 @@ public final class BasicInfo {
         }
 
         final BasicInfo other = (BasicInfo) obj;
-        return keyword.equals(other.keyword) && name.equals(other.name) && arguments.equals(other.arguments);
+        return keyword.equals(other.keyword) && name.equals(other.name) && arguments.equals(other.arguments) && location.equals(other.location);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(keyword, name, arguments);
+        return Objects.hash(keyword, name, location, arguments);
     }
 
     @Override
     public String toString() {
         final StringBuilder builder = new StringBuilder();
         builder.append(keyword).append(": ").append(name);
+        builder.append("; location = ").append(location);
         if (!arguments.isEmpty()) {
             builder.append("; arguments = ").append(arguments);
         }

--- a/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/shared/views/BasicInfoConverter.java
+++ b/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/shared/views/BasicInfoConverter.java
@@ -13,7 +13,7 @@ class BasicInfoConverter extends CustomConverter<BasicInfo, BasicInfo> {
             return null;
         }
 
-        return new BasicInfo(source.getKeyword(), source.getName(), source.getArguments());
+        return new BasicInfo(source.getKeyword(), source.getName(), source.getLocation(), source.getArguments());
     }
 
 }

--- a/zucchini-ui-backend/src/test/java/io/zucchiniui/backend/feature/domain/FeatureTest.java
+++ b/zucchini-ui-backend/src/test/java/io/zucchiniui/backend/feature/domain/FeatureTest.java
@@ -16,9 +16,7 @@ public class FeatureTest {
 
     private static final String TEST_RUN_ID = "testRunId";
 
-    private static final BasicInfo INFO = new BasicInfo("Feature", "test");
-
-    private static final Location LOCATION = new Location("file.feature", 5);
+    private static final BasicInfo INFO = new BasicInfo("Feature", "test", new Location("file.feature", 5));
 
     @Test
     public void should_create_feature() throws Exception {
@@ -26,14 +24,13 @@ public class FeatureTest {
         final ZonedDateTime testStartDate = ZonedDateTime.now();
 
         // when
-        final Feature feature = new Feature(FEATURE_KEY, TEST_RUN_ID, INFO, LOCATION, "en");
+        final Feature feature = new Feature(FEATURE_KEY, TEST_RUN_ID, INFO, "en");
 
         // then
         assertThat(feature.getId()).isNotEmpty();
         assertThat(feature.getFeatureKey()).isEqualTo(FEATURE_KEY);
         assertThat(feature.getTestRunId()).isEqualTo(TEST_RUN_ID);
         assertThat(feature.getInfo()).isEqualTo(INFO);
-        assertThat(feature.getLocation()).isEqualTo(LOCATION);
         assertThat(feature.getStatus()).isEqualTo(FeatureStatus.NOT_RUN);
         assertThat(feature.getGroup()).isNull();
         assertThat(feature.getDescription()).isNull();
@@ -50,7 +47,7 @@ public class FeatureTest {
         // given
         final FeatureStatus newStatus = FeatureStatus.PASSED;
 
-        final Feature feature = new Feature(FEATURE_KEY, TEST_RUN_ID, INFO, LOCATION, "en");
+        final Feature feature = new Feature(FEATURE_KEY, TEST_RUN_ID, INFO, "en");
 
         // when
 
@@ -66,7 +63,7 @@ public class FeatureTest {
         // given
         final String newGroup = "newGroup";
 
-        final Feature feature = new Feature(FEATURE_KEY, TEST_RUN_ID, INFO, LOCATION, "en");
+        final Feature feature = new Feature(FEATURE_KEY, TEST_RUN_ID, INFO, "en");
 
         // when
 
@@ -82,7 +79,7 @@ public class FeatureTest {
         // given
         final String newDescription = "newGroup";
 
-        final Feature feature = new Feature(FEATURE_KEY, TEST_RUN_ID, INFO, LOCATION, "en");
+        final Feature feature = new Feature(FEATURE_KEY, TEST_RUN_ID, INFO, "en");
 
         // when
 
@@ -98,7 +95,7 @@ public class FeatureTest {
         // given
         final Set<String> newTags = Sets.newHashSet("titi", "toto", "tutu");
 
-        final Feature feature = new Feature(FEATURE_KEY, TEST_RUN_ID, INFO, LOCATION, "en");
+        final Feature feature = new Feature(FEATURE_KEY, TEST_RUN_ID, INFO, "en");
 
         // when
 
@@ -112,7 +109,7 @@ public class FeatureTest {
     @Test
     public void should_merge_with_another_feature() throws Exception {
         // given
-        final Feature sourceFeature = new Feature(FEATURE_KEY, TEST_RUN_ID, INFO, LOCATION, "en");
+        final Feature sourceFeature = new Feature(FEATURE_KEY, TEST_RUN_ID, INFO, "en");
         sourceFeature.setGroup("group");
         sourceFeature.setTags(Sets.newHashSet("titi", "toto", "tutu"));
         sourceFeature.setDescription("Description");
@@ -121,8 +118,7 @@ public class FeatureTest {
         final Feature targetFeature = new Feature(
             FEATURE_KEY,
             TEST_RUN_ID,
-            new BasicInfo("Feature", "other"),
-            new Location("other.feature", 1),
+            new BasicInfo("Feature", "other",new Location("other.feature", 1)),
             "en"
         );
 

--- a/zucchini-ui-backend/src/test/java/io/zucchiniui/backend/scenario/domain/BackgroundTest.java
+++ b/zucchini-ui-backend/src/test/java/io/zucchiniui/backend/scenario/domain/BackgroundTest.java
@@ -1,6 +1,7 @@
 package io.zucchiniui.backend.scenario.domain;
 
 import io.zucchiniui.backend.shared.domain.BasicInfo;
+import io.zucchiniui.backend.shared.domain.Location;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,11 +47,15 @@ public class BackgroundTest {
 
     private static Background createBackground() {
         return new BackgroundBuilder()
-            .withInfo(new BasicInfo("Background", "test"))
-            .addStep(stepBuilder -> stepBuilder.withInfo(new BasicInfo("Step", "step 1")).withStatus(StepStatus.PASSED))
-            .addStep(stepBuilder -> stepBuilder.withInfo(new BasicInfo("Step", "step 2")).withStatus(StepStatus.PASSED))
-            .addStep(stepBuilder -> stepBuilder.withInfo(new BasicInfo("Step", "step 3")).withStatus(StepStatus.FAILED).withErrorMessage("error"))
+            .withInfo(new BasicInfo("Background", "test", new Location("filename", 1L)))
+            .addStep(stepBuilder -> stepBuilder.withInfo(generateBasicInfo(1)).withStatus(StepStatus.PASSED))
+            .addStep(stepBuilder -> stepBuilder.withInfo(generateBasicInfo(2)).withStatus(StepStatus.PASSED))
+            .addStep(stepBuilder -> stepBuilder.withInfo(generateBasicInfo(3)).withStatus(StepStatus.FAILED).withErrorMessage("error"))
             .build();
+    }
+
+    private static BasicInfo generateBasicInfo(long stepNumber) {
+        return new BasicInfo("Step", "step " + stepNumber, new Location("filename", stepNumber));
     }
 
 }

--- a/zucchini-ui-backend/src/test/java/io/zucchiniui/backend/scenario/domain/ScenarioTest.java
+++ b/zucchini-ui-backend/src/test/java/io/zucchiniui/backend/scenario/domain/ScenarioTest.java
@@ -1,6 +1,7 @@
 package io.zucchiniui.backend.scenario.domain;
 
 import io.zucchiniui.backend.shared.domain.BasicInfo;
+import io.zucchiniui.backend.shared.domain.Location;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -187,8 +188,8 @@ public class ScenarioTest {
             .withFeatureId(featureId)
             .withScenarioKey(scenarioKey)
             .withLanguage("en")
-            .withInfo(new BasicInfo("Feature A", "Feature name A"))
-            .addStep(sb -> sb.withInfo(new BasicInfo("Step", "Step E")).withStatus(StepStatus.PASSED))
+            .withInfo(new BasicInfo("Feature A", "Feature name A", generateLocation()))
+            .addStep(sb -> sb.withInfo(new BasicInfo("Step", "Step E", generateLocation())).withStatus(StepStatus.PASSED))
             .build();
 
         final Scenario inputScenario = new ScenarioBuilder()
@@ -196,22 +197,22 @@ public class ScenarioTest {
             .withFeatureId(featureId)
             .withScenarioKey(scenarioKey)
             .withLanguage("en")
-            .withInfo(new BasicInfo("Feature B", "Feature name B"))
+            .withInfo(new BasicInfo("Feature B", "Feature name B", generateLocation()))
             .withComment("Feature comment")
             .withTags(Collections.singleton("toto"))
             .withExtraTags(Collections.singleton("tutu"))
             .addBeforeAction(sb -> sb.withStatus(StepStatus.FAILED).withErrorMessage("Error A"))
             .withBackground(bb -> {
-                bb.withInfo(new BasicInfo("Background", "Background C"));
+                bb.withInfo(new BasicInfo("Background", "Background C", generateLocation()));
                 bb.addStep(sb -> {
-                    sb.withInfo(new BasicInfo("Step", "Step D"))
+                    sb.withInfo(new BasicInfo("Step", "Step D", generateLocation()))
                         .withStatus(StepStatus.FAILED)
                         .withErrorMessage("Error B")
                         .withOutput("Failed output")
                         .withComment("Comment A");
                 });
             })
-            .addStep(sb -> sb.withInfo(new BasicInfo("Step", "Step E")).withStatus(StepStatus.FAILED).withErrorMessage("Error C").withComment("Comment B"))
+            .addStep(sb -> sb.withInfo(new BasicInfo("Step", "Step E", generateLocation())).withStatus(StepStatus.FAILED).withErrorMessage("Error C").withComment("Comment B"))
             .addAfterAction(sb -> sb.withStatus(StepStatus.FAILED).withErrorMessage("Error D"))
             .build();
 
@@ -346,7 +347,7 @@ public class ScenarioTest {
             .withFeatureId(UUID.randomUUID().toString())
             .withScenarioKey(UUID.randomUUID().toString())
             .withLanguage("en")
-            .withInfo(new BasicInfo("Feature", "Test"));
+            .withInfo(new BasicInfo("Feature", "Test", generateLocation()));
 
         private Consumer<BackgroundBuilder> backgroundBuilderConsumer;
 
@@ -362,18 +363,18 @@ public class ScenarioTest {
 
         public StatusTestScenarioBuilder withBackgroundStep(final StepStatus status) {
             if (backgroundBuilderConsumer == null) {
-                backgroundBuilderConsumer = bb -> bb.withInfo(new BasicInfo("Background", "Test"));
+                backgroundBuilderConsumer = bb -> bb.withInfo(new BasicInfo("Background", "Test", generateLocation()));
             }
 
             backgroundBuilderConsumer = backgroundBuilderConsumer.andThen(bb -> {
-                bb.addStep(sb -> sb.withInfo(new BasicInfo("Step", "Test")).withStatus(status));
+                bb.addStep(sb -> sb.withInfo(new BasicInfo("Step", "Test", generateLocation())).withStatus(status));
             });
 
             return this;
         }
 
         public StatusTestScenarioBuilder withStep(final StepStatus status) {
-            scenarioBuilder.addStep(sb -> sb.withInfo(new BasicInfo("Step", "Test")).withStatus(status));
+            scenarioBuilder.addStep(sb -> sb.withInfo(new BasicInfo("Step", "Test", generateLocation())).withStatus(status));
             return this;
         }
 
@@ -384,6 +385,10 @@ public class ScenarioTest {
             return scenarioBuilder.build();
         }
 
+    }
+
+    private static Location generateLocation() {
+        return new Location("filename", 1L);
     }
 
 }

--- a/zucchini-ui-backend/src/test/java/io/zucchiniui/backend/scenario/domain/StepTest.java
+++ b/zucchini-ui-backend/src/test/java/io/zucchiniui/backend/scenario/domain/StepTest.java
@@ -1,6 +1,7 @@
 package io.zucchiniui.backend.scenario.domain;
 
 import io.zucchiniui.backend.shared.domain.BasicInfo;
+import io.zucchiniui.backend.shared.domain.Location;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,7 +38,7 @@ public class StepTest {
 
     private static Step createStep() {
         return new StepBuilder()
-            .withInfo(new BasicInfo("Step", "step1"))
+            .withInfo(new BasicInfo("Step", "step1", new Location("filename", 3L)))
             .withStatus(StepStatus.FAILED)
             .withErrorMessage("error")
             .withComment("comment")

--- a/zucchini-ui-backend/src/test/java/io/zucchiniui/backend/shared/domain/BasicInfoPropertiesTest.java
+++ b/zucchini-ui-backend/src/test/java/io/zucchiniui/backend/shared/domain/BasicInfoPropertiesTest.java
@@ -20,17 +20,20 @@ public class BasicInfoPropertiesTest {
     public void infos_with_same_values_should_be_equal(
         final String keyword,
         final String name,
+        final @From(LocationGenerator.class) Location location,
         final List<@From(ArgumentGenerator.class) Argument> arguments
     ) throws Exception {
         final BasicInfo leftInfo = new BasicInfo(
             keyword,
             name,
+            location,
             arguments
         );
 
         final BasicInfo rightInfo = new BasicInfo(
             keyword,
             name,
+            location,
             arguments
         );
 
@@ -51,6 +54,21 @@ public class BasicInfoPropertiesTest {
             final int offset = random.nextInt(Integer.MAX_VALUE);
             final String value = stringGenerator.generate(random, status);
             return new Argument(offset, value);
+        }
+
+    }
+
+    public static class LocationGenerator extends Generator<Location> {
+
+        private final StringGenerator stringGenerator = new StringGenerator();
+
+        public LocationGenerator() {
+            super(Location.class);
+        }
+
+        @Override
+        public Location generate(SourceOfRandomness random, GenerationStatus status) {
+            return new Location(stringGenerator.generate(random, status), random.nextLong(1, Long.MAX_VALUE));
         }
 
     }

--- a/zucchini-ui-backend/src/test/java/io/zucchiniui/backend/shared/domain/BasicInfoTest.java
+++ b/zucchini-ui-backend/src/test/java/io/zucchiniui/backend/shared/domain/BasicInfoTest.java
@@ -13,12 +13,14 @@ public class BasicInfoTest {
 
     private static final String NAME = "name";
 
+    private static final Location LOCATION = new Location("filename", 1L);
+
     @Test
     public void should_create_info_with_no_arguments() throws Exception {
         // given
 
         // when
-        final BasicInfo info = new BasicInfo(KEYWORD, NAME);
+        final BasicInfo info = new BasicInfo(KEYWORD, NAME, LOCATION);
 
         // then
         assertThat(info.getKeyword()).isEqualTo(KEYWORD);
@@ -35,7 +37,7 @@ public class BasicInfoTest {
         );
 
         // when
-        final BasicInfo info = new BasicInfo(KEYWORD, NAME, arguments);
+        final BasicInfo info = new BasicInfo(KEYWORD, NAME, LOCATION, arguments);
 
         // then
         assertThat(info.getKeyword()).isEqualTo(KEYWORD);

--- a/zucchini-ui-frontend/src/feature/components/FeaturePage.jsx
+++ b/zucchini-ui-frontend/src/feature/components/FeaturePage.jsx
@@ -71,7 +71,7 @@ export default class FeaturePage extends React.Component {
         )}
 
         <p>
-          <b>Source :</b> <code>{feature.location.filename}</code>, ligne <code>{feature.location.line}</code>
+          <b>Source :</b> <code>{feature.info.location.filename}</code>, ligne <code>{feature.info.location.line}</code>
         </p>
 
         {feature.tags.length > 0 && (

--- a/zucchini-ui-frontend/src/feature/redux.js
+++ b/zucchini-ui-frontend/src/feature/redux.js
@@ -99,8 +99,9 @@ export function deleteFeature({ featureId }) {
 
 const initialState = {
   feature: {
-    info: {},
-    location: {},
+    info: {
+      location: {}
+    },
     tags: []
   },
   stats: model.createStatsWithZeros(),

--- a/zucchini-ui-mongo/migrations/0010-add-default-location.js
+++ b/zucchini-ui-mongo/migrations/0010-add-default-location.js
@@ -1,0 +1,26 @@
+migrate(() => {
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  /////////// WARNING : SLOW QUERIES !!!  FOR EXAMPLE: IT TOOK 160s TO UPDATE 266204 DOCUMENTS /////////////////////////////////
+  /////////// PLEASE CONSIDER NOTICEABLE SHORTAGE DURING MIGRATION (DEPENDING ON NUMBER OF FEATURES + SCENARIOS)////////////////
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+// Moving feature's location field to basicInfo attribute
+  db.features.updateMany({'location': {$exists: true}}, {$rename: {'location': 'info.location'}});
+
+// Defaulting missing scenario & steps locations to a default value
+// Notes:
+// - The "real" locations are only available on imports (cucumber.json)
+// - All existing scenarios (before this feature) do not have any 'real' locations
+// - Thus, we use static values as placeholders for the migration
+  db.scenarii.updateMany(
+    {'steps': {$exists: true}, 'steps.info.location': {$exists: false}, 'info.location': {$exists: false}},
+    {
+      $set: {
+        'info.location': {'filename': 'zucchini-migration-init.feature', 'line': NumberLong(1)},
+        'steps.$.info.location': {'filename': 'zucchini-migration-init.feature', 'line': NumberLong(1)}
+      }
+    });
+
+});


### PR DESCRIPTION
Hello,

The aim of this PR is to allow Zucchini to rebuild [Cucumber Rerun logs](https://relishapp.com/cucumber/cucumber/docs/formatters/rerun-formatter).

A cucumber rerun log is nothing more than a list of coordinates of failed scenarios:

> features/my-super-group/my-super-failed.feature:45 features/other-group/my-other-super-failed.feature:77 

To achieve this, my solution is that every scenario/feature/step should always return their location.
Thus, if we want to build rerun logs, we can rebuild this by fetching **all failed scenarios and aggregate their locations.**

Moreover, this feature also allows to create arbitrary runs (based on whatever rule to select scenarios for the run).