### PR TITLE
Fixed campaign api performance issue

### DIFF
--- a/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/campaign/domainimpl/CampaignServiceImpl.java
+++ b/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/campaign/domainimpl/CampaignServiceImpl.java
@@ -52,6 +52,8 @@ public class CampaignServiceImpl implements CampaignService {
     private CampaignTestRunScenariosStats computeScenariosStats(TestRun testRun) {
         final List<Scenario> scenarios = scenarioDAO.createQuery()
             .field("testRunId").equal(testRun.getId())
+            .project("status",true)
+            .project("reviewed",true)
             .asList();
         final CampaignTestRunScenariosStats.Builder builder = new CampaignTestRunScenariosStats.Builder()
             .withAll(scenarios.size())


### PR DESCRIPTION
In order to greatly reduce campaign stats API issue, I use mongo field projection to retrieve only fields I need for computing campaign stats 